### PR TITLE
Feature: adding GAIN as a parameter for the dump1090 service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #
 # NOTE: This is the UNOPTIMISED Dockerfile.
-# 
+#
 # Production releases of this image use an optimised Dockerfile with many less layers.
 # See Dockerfile.amd64, Dockerfile.armv7l & Dockerfile.aarch64 in source repo, these are the optimised versions.
 #
@@ -16,7 +16,8 @@ ENV BRANCH_PIAWARE=v3.7.1 \
     BRANCH_TCLLIB=tcllib-1-18-1 \
     VERSION_S6OVERLAY=v1.22.1.0 \
     ARCH_S6OVERLAY=amd64 \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    GAIN=-10
 #    BRANCH_DUMP978=v3.7.1 \
 #    BRANCH_SOAPYSDR=soapy-sdr-0.5.4 \
 
@@ -81,9 +82,9 @@ RUN git clone -b ${BRANCH_TCLLIB} https://github.com/tcltk/tcllib.git /src/tclli
     autoconf && \
     ./configure && \
     make -j && \
-    make -j install 
+    make -j install
 
-# Install and Patch (https://aur.archlinux.org/packages/piaware-git/) piaware    
+# Install and Patch (https://aur.archlinux.org/packages/piaware-git/) piaware
 RUN git clone -b ${BRANCH_PIAWARE} https://github.com/flightaware/piaware.git /src/piaware && \
     cp -v /src/piaware/programs/piaware/faup.tcl /src/piaware/programs/piaware/faup.tcl.original && \
     sed -i 's/package require Itcl 3.4/package require Itcl/' /src/piaware/programs/piaware/faup.tcl

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,7 +7,8 @@ ENV BRANCH_PIAWARE=v3.7.1 \
     BRANCH_TCLLIB=tcllib-1-18-1 \
     VERSION_S6OVERLAY=v1.22.1.0 \
     ARCH_S6OVERLAY=aarch64 \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    GAIN=-10
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/${VERSION_S6OVERLAY}/s6-overlay-${ARCH_S6OVERLAY}.tar.gz /tmp/s6-overlay.tar.gz
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -7,7 +7,8 @@ ENV BRANCH_PIAWARE=v3.7.1 \
     BRANCH_TCLLIB=tcllib-1-18-1 \
     VERSION_S6OVERLAY=v1.22.1.0 \
     ARCH_S6OVERLAY=amd64 \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    GAIN=-10
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/${VERSION_S6OVERLAY}/s6-overlay-${ARCH_S6OVERLAY}.tar.gz /tmp/s6-overlay.tar.gz
 

--- a/Dockerfile.armv7l
+++ b/Dockerfile.armv7l
@@ -7,7 +7,8 @@ ENV BRANCH_PIAWARE=v3.7.1 \
     BRANCH_TCLLIB=tcllib-1-18-1 \
     VERSION_S6OVERLAY=v1.22.1.0 \
     ARCH_S6OVERLAY=armhf \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    GAIN=-10
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/${VERSION_S6OVERLAY}/s6-overlay-${ARCH_S6OVERLAY}.tar.gz /tmp/s6-overlay.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently, this image should pull and run on the following architectures:
  * ```amd64```: Linux x86-64
  * ```arm32v7```, ```armv7l```: ARMv7 32-bit (Odroid HC1/HC2/XU4, RPi 2/3)
  * ```arm64v8```, ```aarch64```: ARMv8 64-bit (RPi 3B+/4)
- 
+
 ## Prerequisites
 
 Before this container will work properly, you must blacklist the kernel modules for the RTL-SDR USB device from the host's kernel.
@@ -72,7 +72,7 @@ Failure to do this will result in the error below being spammed to the container
 2019-04-29 21:14:31.642500500  [dump1090-fa] Kernel driver is active, or device is claimed by second instance of librtlsdr.
 2019-04-29 21:14:31.642635500  [dump1090-fa] In the first case, please either detach or blacklist the kernel module
 2019-04-29 21:14:31.642663500  [dump1090-fa] (dvb_usb_rtl28xxu), or enable automatic detaching at compile time.
-2019-04-29 21:14:31.642677500  [dump1090-fa] 
+2019-04-29 21:14:31.642677500  [dump1090-fa]
 2019-04-29 21:14:31.642690500  [dump1090-fa] usb_claim_interface error -6
 ```
 
@@ -185,6 +185,7 @@ docker run \
 There are a series of available variables you are required to set:
 
 * `TZ` - Your local timezone (optional)
+* `GAIN` - Optimizing gain which defaults to -10 https://discussions.flightaware.com/t/thoughts-on-optimizing-gain/44482/2 (optional)
 * `USERNAME` - FlightAware account username
 * `PASSWORD` - FlightAware account password
 * `LAT` - Antenna's latitude

--- a/etc/cont-init.d/01-piaware
+++ b/etc/cont-init.d/01-piaware
@@ -19,6 +19,9 @@ if [ -z "${LONG}" ]; then
   echo "ERROR: LONG environment variable not set"
   EXITCODE=1
 fi
+if [ -z "${GAIN}" ]; then
+  echo "INFO: GAIN will be set to default max; -10"
+fi
 echo -ne "\e[0m"
 if [ $EXITCODE -ne 0 ]; then
   exit 1
@@ -36,6 +39,7 @@ fi
 # Set up piaware
 piaware-config flightaware-user ${USERNAME}
 piaware-config flightaware-password ${PASSWORD}
+piaware-config rtlsdr-gain ${GAIN}
 piaware-config allow-auto-updates no
 piaware-config allow-manual-updates no
 

--- a/etc/services.d/dump1090/run
+++ b/etc/services.d/dump1090/run
@@ -1,10 +1,11 @@
 #!/usr/bin/with-contenv sh
 
+
 set -eo pipefail
 
 /usr/local/bin/dump1090 \
     --net \
-    --gain -10 \
+    --gain ${GAIN} \
     --ppm 1 \
     --lat ${LAT} \
     --lon ${LONG} \
@@ -16,4 +17,3 @@ set -eo pipefail
     --write-json /run/dump1090-fa \
     --json-location-accuracy 2 \
     2>&1 | awk '{print "[dump1090-fa] " $0}'
-


### PR DESCRIPTION
I use your image in a nomad cluster, recently I stumbled on https://discussions.flightaware.com/t/thoughts-on-optimizing-gain/44482/2 where there is the possibility to play around with the gain to optimize the percentage of strong messages.

Therefor I tried to enhance your image to be able to give the GAIN through as a parameter. By default it will fall back to -10 (max) when the option isn't given through as an ENV parameter.

Do not hesitate to give feedback, suggestions, ..