### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ Tested and working on:
 
 ## Changelog
 
+### 20200407
+
+* When using an external Beast provider, remove the need to map `dump1090`/`readsb` JSON data into the container for SkyAware to function
+
 ### 20200319
+
 * Include changes and tidy-up from ShoGinn [pull request #13](https://github.com/mikenye/docker-piaware/pull/13)
 
 ### 20200317

--- a/etc/services.d/beastproxy/run
+++ b/etc/services.d/beastproxy/run
@@ -6,5 +6,5 @@ if [ -z "${BEASTHOST}" ]; then
   sleep 3600
 else
   exec \
-    socat -d -d TCP-LISTEN:30005,fork TCP:"${BEASTHOST}:${BEASTPORT}" 2>&1 | awk '{print "[beastrelay] " $0}'
+    socat -d -d TCP-LISTEN:30005,fork TCP:"${BEASTHOST}:${BEASTPORT}" 2>&1 | awk '{print "[beastproxy] " $0}'
 fi

--- a/etc/services.d/beastproxy/run
+++ b/etc/services.d/beastproxy/run
@@ -1,7 +1,9 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# Build the dump1090 command line based on piaware options
+# When running with an external beast provider, we map the external beast
+# provider on localhost:30005, to mimic dump1090 doing this.
+
 if [ -z "${BEASTHOST}" ]; then
   sleep 3600
 else

--- a/etc/services.d/beastrelay/run
+++ b/etc/services.d/beastrelay/run
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+# Build the dump1090 command line based on piaware options
+if [ -z "${BEASTHOST}" ]; then
+  sleep 3600
+else
+  exec \
+    socat -d -d TCP:"${BEASTHOST}:${BEASTPORT}" TCP:localhost:30004 2>&1 | awk '{print "[beastproxy] " $0}'
+fi

--- a/etc/services.d/beastrelay/run
+++ b/etc/services.d/beastrelay/run
@@ -1,10 +1,13 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# Build the dump1090 command line based on piaware options
+# When running with an external beast provider, we push the beast traffic
+# into the local dump1090 instance. This allows JSON data to be written, 
+# and SkyAware to function normally.
+
 if [ -z "${BEASTHOST}" ]; then
   sleep 3600
 else
   exec \
-    socat -d -d TCP:"${BEASTHOST}:${BEASTPORT}" TCP:localhost:30004 2>&1 | awk '{print "[beastproxy] " $0}'
+    socat -d -d TCP:"${BEASTHOST}:${BEASTPORT}" TCP:localhost:30004 2>&1 | awk '{print "[beastrelay] " $0}'
 fi

--- a/etc/services.d/dump1090/run
+++ b/etc/services.d/dump1090/run
@@ -18,12 +18,16 @@ if [ -z "${BEASTHOST}" ]; then
   DUMP1090_CMD+=(--gain "${RTLSDR_GAIN}")
   RTLSDR_PPM=$(piaware-config -show rtlsdr-ppm)
   DUMP1090_CMD+=(--ppm "${RTLSDR_PPM}")
-  DUMP1090_CMD+=(--stats-every 3600)
-  DUMP1090_CMD+=(--write-json /run/dump1090-fa)
-  DUMP1090_CMD+=(--json-location-accuracy 2)
 else
-  DUMP1090_CMD+=(--net-only --net-bo-port 0)
+  DUMP1090_CMD+=(--net-only)
+  DUMP1090_CMD+=(--net-bo-port 0)
+  DUMP1090_CMD+=(--net-bi-port 30004)
+  
 fi
+
+DUMP1090_CMD+=(--stats-every 3600)
+DUMP1090_CMD+=(--write-json /run/dump1090-fa)
+DUMP1090_CMD+=(--json-location-accuracy 2)
 
 if [ "$ALLOW_MODEAC" = "yes" ]; then
   DUMP1090_CMD+=(--modeac)

--- a/etc/services.d/dump1090/run
+++ b/etc/services.d/dump1090/run
@@ -19,9 +19,14 @@ if [ -z "${BEASTHOST}" ]; then
   RTLSDR_PPM=$(piaware-config -show rtlsdr-ppm)
   DUMP1090_CMD+=(--ppm "${RTLSDR_PPM}")
 else
+
+  # If an external beast provider is used, then operate in net-only mode.
+  # Also, don't provide beast on port 30005 (net-bo-port), as socat will do this.
+  # Also, listen for beast in on ports 30004,30104, so socat an inject beast data.
+
   DUMP1090_CMD+=(--net-only)
   DUMP1090_CMD+=(--net-bo-port 0)
-  DUMP1090_CMD+=(--net-bi-port 30004)
+  DUMP1090_CMD+=(--net-bi-port 30004,30104)
   
 fi
 


### PR DESCRIPTION
When using an external Beast provider, remove the need to map `dump1090`/`readsb` JSON data into the container for SkyAware to function