### PR TITLE
Fix issue #15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     ALLOW_MLAT=yes \
     RTLSDR_GAIN=-10 \
     RTLSDR_PPM=0 \
-    BEASTPORT=30005
+    BEASTPORT=30005 \
+    BRANCH_RTLSDR="d794155ba65796a76cd0a436f9709f4601509320"
+
+# Note, the specific commit of rtlsdr is to address issue #15
+# See: https://github.com/mikenye/docker-piaware/issues/15
+# This should be revisited in future when rtlsdr 0.6.1 or newer is released
 
 RUN set -x && \
     apk update && \
@@ -42,8 +47,9 @@ RUN set -x && \
     echo "========== Install RTL-SDR ==========" && \
     git clone git://git.osmocom.org/rtl-sdr.git /src/rtl-sdr && \
     cd /src/rtl-sdr && \
-    export BRANCH_RTLSDR=$(git tag --sort="-creatordate" | head -1) && \
-    git checkout tags/${BRANCH_RTLSDR} && \
+    #export BRANCH_RTLSDR=$(git tag --sort="-creatordate" | head -1) && \
+    #git checkout tags/${BRANCH_RTLSDR} && \
+    git checkout "${BRANCH_RTLSDR}" && \
     echo "rtl-sdr ${BRANCH_RTLSDR}" >> /VERSIONS && \
     mkdir -p /src/rtl-sdr/build && \
     cd /src/rtl-sdr/build && \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Tested and working on:
 | tag                | `piaware` | `rtl-sdr` | `dump1090-fa` | `bladeRF`          | `mlat-client` | `SoapySDR` | `dump978` | Base Image    |
 |--------------------|-----------|-----------|---------------|--------------------|---------------|------------|-----------|---------------|
 | `latest`,<br> `v3.8.1` | 3.8.1     | 0.6.0     | 3.8.1         | 1.8.0-git-991bba2f | 0.2.11        | 0.7.2      | 3.8.1     | Alpine 3.11.5 |
-| `latest-rtlsdr-v0.5.3`,<br>`v3.8.1-rtlsdr-v0.5.3` | 3.8.1     | 0.5.3     | 3.8.1         | 1.8.0-git-991bba2f | 0.2.11        | 0.7.2      | 3.8.1     | Alpine 3.11.5 |
 | `v3.8.0` | 3.8.0     | 0.6.0     | 3.8.0         | 1.8.0-git-991bba2f | 0.2.11        | 0.7.2      | 3.8.0     | Alpine 3.11.3 |
 | `3.7.2`  | 3.7.2     | 0.6       | 3.7.2         | 1.5.1-git-0f84cc76 | 0.2.10        | N/A        | N/A       | Alpine 3.9.4  |
 | `3.7.1`  | 3.7.1     | 0.6       | 3.7.1         | 1.5.1-git-0f84cc76 | 0.2.10        | N/A        | N/A       | Alpine 3.9.3  |
@@ -38,6 +37,10 @@ Tested and working on:
 * Thanks to [ShoGinn](https://github.com/ShoGinn) for many contributions to the 3.8.0 release and tidy up of code & readme.
 
 ## Changelog
+
+### 20200429
+
+* Change version of `rtl-sdr` to address incompatibility with `RTL2838UHIDIR` hardware. Thanks to Ryan Guzy for troubleshooting. This negates the needed for specific tags for `rtl-sdr` version 0.5.3 - these have now been deprecated.
 
 ### 20200417
 


### PR DESCRIPTION
- Use a specific commit of `rtlsdr` v0.6.0 that appears to fix compatibility issues with `RTL2838UHIDIR`
- Fix compilation issues of `dump1090` as a result of `rtlsdr`'s broken `pkg-config` file (likely related to compiling on Alpine and not an issue with `rtlsdr`). Fix as per: https://github.com/antirez/dump1090/issues/142#issuecomment-517997954.
- Update README.md to reference deprecation of `*-rtlsdr-v0.5.3` image tags, as these are no longer required with the specific `rtlsdr` version.