### PR TITLE
Implement suggestion in issue #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,14 @@ Please feel free to [open an issue on the project's GitHub](https://github.com/m
 
 ## Changelog
 
+### 20200505
+
+* Implement suggestion in [issue #24](https://github.com/mikenye/docker-piaware/issues/24#issue-612402611). Once `piaware` connects to FlightAware's servers and retrieves a personal stats URL, the FlightAware logo in SkyAware will be modified to link to the feeder's personal stats URL. You'll see an entry in the log such as:
+
+```
+[statsurlupdater] Updating SkyAware link to: https://flightaware.com/adsb/stats/user/xxxxxxx#stats-xxxxx
+```
+
 ### 20200502
 
 * Fix issue with `fa-mlat-client` not working and add `procps` package, see [issue #21](https://github.com/mikenye/docker-piaware/issues/21)

--- a/etc/cont-init.d/01-piaware
+++ b/etc/cont-init.d/01-piaware
@@ -39,3 +39,7 @@ piaware-config allow-mlat "${ALLOW_MLAT}"
 piaware-config allow-modeac "${ALLOW_MODEAC}"
 piaware-config allow-auto-updates no
 piaware-config allow-manual-updates no
+
+# Create log dir for piaware
+mkdir -p /var/log/piaware
+chown nobody:nogroup /var/log/piaware

--- a/etc/services.d/piaware/log/run
+++ b/etc/services.d/piaware/log/run
@@ -1,0 +1,7 @@
+#!/usr/bin/execlineb
+#shellcheck shell=sh
+
+s6-envuidgid nobody
+s6-applyuidgid -U
+
+s6-log -bp 1 n5 s1000000 S10000000 T /var/log/piaware

--- a/etc/services.d/statsurlupdater/run
+++ b/etc/services.d/statsurlupdater/run
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#shellcheck shell=bash
+
+sleep 10
+
+# Check to see if we've already updated the stats url
+if [ -f "/.statsurlupdated" ]; then
+    # do nothing, sleep forever
+    sleep 3600
+
+else
+    # attempt to update the url
+
+    # check to see if our site statistics url has made it to the log yet
+    grep "site statistics URL:" /var/log/piaware/current > /dev/null
+    if [ $? -ne 0 ]; then
+        # site statistics url not yet found, exit and try again
+        exit 0
+    fi
+
+    STATSURL=$(grep "site statistics URL:" /var/log/piaware/current | cut -d "]" -f 2 | tr -d " " | cut -d ":" -f 2-)
+
+    echo "[statsurlupdater] Updating SkyAware link to: ${STATSURL}"
+
+    OLDURL="http://flightaware.com/"
+
+    sed -i 's,'"${OLDURL}"','"${STATSURL}"',' /usr/share/dump1090-fa/html/index.html
+
+    # touch a state file so this script knows not to process again
+    touch /.statsurlupdated
+    
+fi


### PR DESCRIPTION
Implement suggestion in [issue #24](https://github.com/mikenye/docker-piaware/issues/24#issue-612402611). Once `piaware` connects to FlightAware's servers and retrieves a personal stats URL, the FlightAware logo in SkyAware will be modified to link to the feeder's personal stats URL. You'll see an entry in the log such as:

```
[statsurlupdater] Updating SkyAware link to: https://flightaware.com/adsb/stats/user/xxxxxxx#stats-xxxxx
```
