### PR TITLE
+iproute2 package, it is needed with -e BEASTHOST=ip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN set -x && \
         gcc \
         git \
         gnupg \
+        iproute2 \
         itcl3 \
         libboost-dev \
         libboost-filesystem1.67.0 \
@@ -42,7 +43,6 @@ RUN set -x && \
         make \
         ncurses-dev \
         net-tools \
-        iproute2 \
         pkg-config \
         procps \
         python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN set -x && \
         make \
         ncurses-dev \
         net-tools \
+        iproute2 \
         pkg-config \
         procps \
         python3 \


### PR DESCRIPTION
I have mikenye/readsb running w/ exposing the 30005 port on my host, so I am running piaware with `-e BEASTHOST=192.168.x.x` and I get a ton of these errors in the log output:

```bash
piaware] ip command not found on this version of Linux, you may need to install the iproute2 package and try again                          
[piaware] software failed to determine MAC address of the device.  cannot proceed without it.                                                
[piaware] ip command not found on this version of Linux, you may need to install the iproute2 package and try again                          
[piaware] software failed to determine MAC address of the device.  cannot proceed without it
```

I can exec in and run `apt update; apt install iproute2` and the errors go away and the container starts as expected! =)