### PR TITLE
Allow selection of RTLSDR device by serial number or index value

### DIFF
--- a/etc/services.d/dump1090/run
+++ b/etc/services.d/dump1090/run
@@ -18,7 +18,7 @@ ALLOW_MLAT="$(piaware-config -show allow-mlat | tr '[:upper:]' '[:lower:]')"
 
 # Allow selection of RTLSDR device by serial number or index value
 if [ -n "${DUMP1090_DEVICE}" ]; then
-  DUMP1090_CMD+=(--device ${DUMP1090_DEVICE})
+  DUMP1090_CMD+=(--device ${"DUMP1090_DEVICE}")
 fi
 
 if [ -z "${BEASTHOST}" ]; then

--- a/etc/services.d/dump1090/run
+++ b/etc/services.d/dump1090/run
@@ -16,6 +16,11 @@ DUMP1090_CMD+=(--fix)
 ALLOW_MODEAC="$(piaware-config -show allow-modeac | tr '[:upper:]' '[:lower:]')"
 ALLOW_MLAT="$(piaware-config -show allow-mlat | tr '[:upper:]' '[:lower:]')"
 
+# Allow selection of RTLSDR device by serial number or index value
+if [ -n "${DUMP1090_DEVICE}" ]; then
+  DUMP1090_CMD+=(--device ${DUMP1090_DEVICE})
+fi
+
 if [ -z "${BEASTHOST}" ]; then
   DUMP1090_CMD+=(--gain "${RTLSDR_GAIN}")
   RTLSDR_PPM="$(piaware-config -show rtlsdr-ppm)"

--- a/etc/services.d/dump1090/run
+++ b/etc/services.d/dump1090/run
@@ -18,7 +18,7 @@ ALLOW_MLAT="$(piaware-config -show allow-mlat | tr '[:upper:]' '[:lower:]')"
 
 # Allow selection of RTLSDR device by serial number or index value
 if [ -n "${DUMP1090_DEVICE}" ]; then
-  DUMP1090_CMD+=(--device ${"DUMP1090_DEVICE}")
+  DUMP1090_CMD+=(--device "${DUMP1090_DEVICE}")
 fi
 
 if [ -z "${BEASTHOST}" ]; then


### PR DESCRIPTION
Watch for an environment variable DUMP1090_DEVICE to specify rtlsdr device index or serial number. I needed to use a device index other than 0 as I had other rtlsdr devices attached.  Even with just one rtlsdr passed into the container via usb path the index was > 0.  