### PR TITLE
Update skyaware.lighttpd.conf

### DIFF
--- a/rootfs/etc/lighttpd/skyaware.lighttpd.conf
+++ b/rootfs/etc/lighttpd/skyaware.lighttpd.conf
@@ -4,6 +4,7 @@ server.modules = (
   "mod_compress",
   "mod_redirect",
   "mod_accesslog",
+  "mod_setenv",
 )
 
 server.document-root        = "/var/www/html"
@@ -76,7 +77,7 @@ $SERVER["socket"] == ":8080" {
 }
 
 # Add CORS header
-server.modules += ( "mod_setenv" )
+# server.modules += ( "mod_setenv" )
 $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
   setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
 }
@@ -104,7 +105,7 @@ $SERVER["socket"] == ":8978" {
 }
 
 # Add CORS header
-server.modules += ( "mod_setenv" )
+# server.modules += ( "mod_setenv" )
 $HTTP["url"] =~ "^/skyaware978/data/.*\.json$" {
   setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
 }


### PR DESCRIPTION
```shell
(plugin.c.190) Cannot load plugin mod_setenv more than once, please fix your config (lighttpd may not accept such configs in future releases)
```

 is shown in startup logs. Moving `mod_setenv` to top so it imports only once