### PR TITLE
Fixes for 7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,8 @@ RUN set -x && \
     # Build & install piaware-web
     git clone "https://github.com/flightaware/piaware-web.git" "/src/piaware-web" && \
     cp -Rv /src/piaware-web/web/. /var/www/html/ && \
+    # Symlink for skyaware978
+    ln -vs /usr/share/dump978-fa /usr/share/skyaware978 && \
     # get dump1090 sources
     DUMP1090_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/flightaware/dump1090.git' | grep -v '\^' | cut -d '/' -f 3 | grep '^v.*' | tail -1) && \
     export DUMP1090_VERSION && \

--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ Use only with `RECEIVER_TYPE=relay`.
 | -------------------- | --------------- | ------- | ------- |
 | `BEASTHOST` | a hostname or IP | Specify an external BEAST protocol provider (dump1090/readsb/etc). | |
 | `BEASTPORT` | a port number | Specify the TCP port number of the external BEAST protocol provider. | `30005` |
+| `MLAT_RESULTS_BEASTHOST` | a hostname or IP | Specify an external host where MLAT results should be sent. | |
+| `MLAT_RESULTS_BEASTPORT` | a port number | Specify the TCP port number where MLAT results should be sent. | `30104` |
 
 ### Receiver Configuration (978MHz)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Please see: [Buster-Docker-Fixes](https://github.com/sdr-enthusiasts/Buster-Dock
     * [Multilateration](#multilateration)
     * [Receiver Configuration (1090MHz)](#receiver-configuration-1090mhz)
     * [RTL-SDR Configuration (1090MHz)](#rtl-sdr-configuration-1090mhz)
+      * [Adaptive Gain Configuration (1090MHz)](#adaptive-gain-configuration-1090mhz)
     * [Relay Configuration (1090MHz)](#relay-configuration-1090mhz)
     * [Receiver Configuration (978MHz)](#receiver-configuration-978mhz)
     * [RTL-SDR Configuration (978MHz)](#rtl-sdr-configuration-978mhz)
@@ -451,6 +452,19 @@ Use only with `RECEIVER_TYPE=rtlsdr`.
 | `RTLSDR_PPM`   | a frequency correction in PPM | Configures the dongle PPM correction | `0` |
 | `RTLSDR_GAIN`  | `max` or a numeric gain level | Optimizing gain (optional) -- See [FlightAware -- Optimizing Gain](https://discussions.flightaware.com/t/thoughts-on-optimizing-gain/44482/2) | `max` |
 | `DUMP1090_DEVICE` | rtlsdr device serial number | Configures which dongle to use for 1090MHz reception if there is more than one connected | first available device |
+
+#### Adaptive Gain Configuration (1090MHz)
+
+The following settings control the [adaptive gain configuration](https://github.com/flightaware/dump1090/blob/master/README.adaptive-gain.md) of `dump1090` when using `RECEIVER_TYPE=rtlsdr`.
+
+| Environment Variable | Possible Values | Description | Default |
+| -------------------- | --------------- | ------- | ------- |
+| `DUMP1090_ADAPTIVE_RANGE` | | Set to any value to adjust gain for target dynamic range. | |
+| `DUMP1090_ADAPTIVE_RANGE_TARGET` | A value in dB | Set target dynamic range in dB. | |
+| `DUMP1090_ADAPTIVE_BURST` | | Adjust gain for too-loud message bursts. | |
+| `DUMP1090_ADAPTIVE_MIN_GAIN` | A value in dB | Set gain adjustment range lower limit (dB). | |
+| `DUMP1090_ADAPTIVE_MAX_GAIN` | A value in dB | Set gain adjustment range upper limit (dB). | |
+| `DUMP1090_ADAPTIVE_DUTY_CYCLE` | A percentage | Set adaptive gain duty cycle % (1..100) </br> See [Reducing the CPU cost of adaptive gain](https://github.com/flightaware/dump1090/blob/master/README.adaptive-gain.md#reducing-the-cpu-cost-of-adaptive-gain) | |
 
 ### Relay Configuration (1090MHz)
 

--- a/README.md
+++ b/README.md
@@ -459,9 +459,9 @@ The following settings control the [adaptive gain configuration](https://github.
 
 | Environment Variable | Possible Values | Description | Default |
 | -------------------- | --------------- | ------- | ------- |
-| `DUMP1090_ADAPTIVE_RANGE` | | Set to any value to adjust gain for target dynamic range. | |
+| `DUMP1090_ADAPTIVE_RANGE` | `true` or unset | Set to any value to adjust gain for target dynamic range. | |
 | `DUMP1090_ADAPTIVE_RANGE_TARGET` | A value in dB | Set target dynamic range in dB. | |
-| `DUMP1090_ADAPTIVE_BURST` | | Adjust gain for too-loud message bursts. | |
+| `DUMP1090_ADAPTIVE_BURST` | `true` or unset | Set to any value to adjust gain for too-loud message bursts. | |
 | `DUMP1090_ADAPTIVE_MIN_GAIN` | A value in dB | Set gain adjustment range lower limit (dB). | |
 | `DUMP1090_ADAPTIVE_MAX_GAIN` | A value in dB | Set gain adjustment range upper limit (dB). | |
 | `DUMP1090_ADAPTIVE_DUTY_CYCLE` | A percentage | Set adaptive gain duty cycle % (1..100) </br> See [Reducing the CPU cost of adaptive gain](https://github.com/flightaware/dump1090/blob/master/README.adaptive-gain.md#reducing-the-cpu-cost-of-adaptive-gain) | |

--- a/rootfs/etc/cont-init.d/01-piaware
+++ b/rootfs/etc/cont-init.d/01-piaware
@@ -49,6 +49,9 @@ else
   ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" >/etc/timezone
 fi
 
+# Wipe piaware config, will be re-created below
+rm /etc/piaware.conf > /dev/null 2>&1
+
 # Set up piaware
 piaware-config allow-auto-updates no
 piaware-config allow-manual-updates no
@@ -80,6 +83,11 @@ if [[ -n "$UAT_RECEIVER_HOST" ]]; then
 elif [[ "$UAT_RECEIVER_TYPE" == "rtlsdr" ]]; then
   piaware-config uat-receiver-type "sdr"
 
+fi
+
+# If MLAT_RESULTS_BEAST_CONNECT is specified
+if [[ -n "$MLAT_RESULTS_BEASTHOST" ]]; then
+  piaware-config mlat-results-format "$(piaware-config -show mlat-results-format) beast,connect,${MLAT_RESULTS_BEASTHOST}:${MLAT_RESULTS_BEASTHOST:-30104}"
 fi
 
 # Create log dir for piaware

--- a/rootfs/etc/services.d/dump1090/run
+++ b/rootfs/etc/services.d/dump1090/run
@@ -9,6 +9,9 @@ fi
 if [[ -n "$DUMP1090_DEVICE" ]]; then
   RUN_DUMP1090="true"
 fi
+if [[ -n "$RECEIVER_TYPE" ]]; then
+  RUN_DUMP1090="true"
+fi
 if [[ -z "$RUN_DUMP1090" ]]; then
   sleep 86400
   exit 0

--- a/rootfs/etc/services.d/dump1090/run
+++ b/rootfs/etc/services.d/dump1090/run
@@ -56,6 +56,29 @@ else
         DUMP1090_CMD+=("--gain" "$RTLSDR_GAIN")
     fi
 
+    if [[ -n "$DUMP1090_ADAPTIVE_RANGE" ]]; then
+        DUMP1090_CMD+=("--adaptive-range")
+    fi
+
+    if [[ -n "$DUMP1090_ADAPTIVE_RANGE_TARGET" ]]; then
+        DUMP1090_CMD+=("--adaptive-range-target" "$DUMP1090_ADAPTIVE_RANGE_TARGET")
+    fi
+
+    if [[ -n "$DUMP1090_ADAPTIVE_BURST" ]]; then
+        DUMP1090_CMD+=("--adaptive-burst")
+    fi
+
+    if [[ -n "$DUMP1090_ADAPTIVE_MIN_GAIN" ]]; then
+        DUMP1090_CMD+=("--adaptive-min-gain" "$DUMP1090_ADAPTIVE_MIN_GAIN")
+    fi
+
+    if [[ -n "$DUMP1090_ADAPTIVE_MAX_GAIN" ]]; then
+        DUMP1090_CMD+=("--adaptive-max-gain" "$DUMP1090_ADAPTIVE_MAX_GAIN")
+    fi
+
+    if [[ -n "$DUMP1090_ADAPTIVE_DUTY_CYCLE" ]]; then
+        DUMP1090_CMD+=("--adaptive-duty-cycle" "$DUMP1090_ADAPTIVE_DUTY_CYCLE")
+    fi
 fi
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
- Add symlink for skyaware978 to fix 404 error. Fixes #112 
- Start dump1090 if `RECEIVER_TYPE` set (but not `DUMP1090_DEVICE`). Fixes #123
- Add `MLAT_RESULTS_BEASTHOST` and `MLAT_RESULTS_BEASTPORT`. Fixes #89 
- Add environment variables to control `dump1090` adaptive gain. Fixes #87 
  - `DUMP1090_ADAPTIVE_RANGE`, `DUMP1090_ADAPTIVE_RANGE_TARGET`, `DUMP1090_ADAPTIVE_BURST`, `DUMP1090_ADAPTIVE_MIN_GAIN`, `DUMP1090_ADAPTIVE_MAX_GAIN`, `DUMP1090_ADAPTIVE_DUTY_CYCLE`