### PR TITLE
Fix dump1090 segfaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,11 @@ RUN set -x && \
     popd && \
     mkdir "/src/LimeSuite/builddir" && \
     pushd "/src/LimeSuite/builddir" && \
-    cmake ../ -DCMAKE_BUILD_TYPE=Release && \
+    cmake \
+      ../ \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DENABLE_SIMD_FLAGS=SSE3 \
+      && \
     make -j "$(nproc)" && \
     make install && \
     ldconfig && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN set -x && \
     cmake \
       ../ \
       -DCMAKE_BUILD_TYPE=Release \
-      -DENABLE_SIMD_FLAGS=none \
+      -DCMAKE_INSTALL_PREFIX=/usr \
       && \
     make -j "$(nproc)" && \
     make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN set -x && \
     cmake \
       ../ \
       -DCMAKE_BUILD_TYPE=Release \
-      -DENABLE_SIMD_FLAGS=SSE3 \
+      -DENABLE_SIMD_FLAGS=none \
       && \
     make -j "$(nproc)" && \
     make install && \


### PR DESCRIPTION
Segfault is due to compile-time optimisations in LimeSDR

```
# gdb -ex run --args dump1090
GNU gdb (Debian 10.1-1.7) 10.1.90.20210103-git
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from dump1090...
Starting program: /usr/local/bin/dump1090
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGILL, Illegal instruction.
0x00007ffff7d0f590 in __static_initialization_and_destruction_0(int, int) [clone .constprop.0] () from /usr/local/lib/libLimeSuite.so.20.10-1
(gdb) bt
#0  0x00007ffff7d0f590 in __static_initialization_and_destruction_0(int, int) [clone .constprop.0] () from /usr/local/lib/libLimeSuite.so.20.10-1
#1  0x00007ffff7fe1fe2 in call_init (l=<optimized out>, argc=argc@entry=1, argv=argv@entry=0x7fffffffecf8, env=env@entry=0x7fffffffed08) at dl-init.c:72
#2  0x00007ffff7fe20e9 in call_init (env=0x7fffffffed08, argv=0x7fffffffecf8, argc=1, l=<optimized out>) at dl-init.c:30
#3  _dl_init (main_map=0x7ffff7ffe180, argc=1, argv=0x7fffffffecf8, env=0x7fffffffed08) at dl-init.c:119
#4  0x00007ffff7fd30ca in _dl_start_user () from /lib64/ld-linux-x86-64.so.2
#5  0x0000000000000001 in ?? ()
#6  0x00007fffffffeed8 in ?? ()
#7  0x0000000000000000 in ?? ()
```

Hopefully fixes #123 