### PR TITLE
Remove setting LAT/LONG in the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,20 +128,15 @@ Run the commands:
 
 ```shell
 docker pull ghcr.io/sdr-enthusiasts/docker-piaware:latest
-timeout 30 docker run --rm -e LAT=YOURLATITUDE -e LONG=YOURLONGITUDE ghcr.io/sdr-enthusiasts/docker-piaware:latest | grep "my feeder ID"
+timeout 30 docker run --rm ghcr.io/sdr-enthusiasts/docker-piaware:latest | grep "my feeder ID"
 ```
-
-Be sure to change the following:
-
-* Replace `YOURLATITUDE` with the latitude of your antenna (xx.xxxxx)
-* Replace `YOURLONGITUDE` with the longitude of your antenna (xx.xxxxx)
 
 The command will run the container for 30 seconds, which should be ample time for the container to receive a feeder-id.
 
 For example:
 
 ```shell
-timeout 30 docker run --rm -e LAT=-33.33333 -e LONG=111.11111 ghcr.io/sdr-enthusiasts/docker-piaware:latest | grep "my feeder ID"
+timeout 30 docker run --rm ghcr.io/sdr-enthusiasts/docker-piaware:latest | grep "my feeder ID"
 ```
 
 Will output:
@@ -173,8 +168,6 @@ docker run \
  --name piaware \
  --device /dev/bus/usb \
  -e TZ="Australia/Perth" \
- -e LAT=-33.33333 \
- -e LONG=111.11111 \
  -e FEEDER_ID=c478b1c99-23d3-4376-1f82-47352a28cg37 \
  -e RECEIVER_TYPE=rtlsdr \
  -p 8080:80 \
@@ -202,8 +195,6 @@ services:
       - 30005:30005
     environment:
       - TZ="Australia/Perth"
-      - LAT=-33.33333
-      - LONG=111.11111
       - FEEDER_ID=c478b1c99-23d3-4376-1f82-47352a28cg37
       - RECEIVER_TYPE=rtlsdr
     tmpfs:
@@ -227,8 +218,6 @@ docker run \
  --name piaware \
  --device /dev/bus/usb \
  -e TZ="Australia/Perth" \
- -e LAT=-33.33333 \
- -e LONG=111.11111 \
  -e RECEIVER_TYPE=rtlsdr \
  -e DUMP1090_DEVICE=00001090 \
  -e UAT_RECEIVER_TYPE=rtlsdr \
@@ -261,8 +250,6 @@ services:
       - 30005:30005
     environment:
       - TZ="Australia/Perth"
-      - LAT=-33.33333
-      - LONG=111.11111
       - FEEDER_ID=c478b1c99-23d3-4376-1f82-47352a28cg37
       - RECEIVER_TYPE=rtlsdr
       - DUMP1090_DEVICE=00001090
@@ -288,8 +275,6 @@ docker run \
  --rm \
  --name piaware \
  -e TZ="Australia/Perth" \
- -e LAT=-33.33333 \
- -e LONG=111.11111 \
  -e RECEIVER_TYPE=relay \
  -e BEASTHOST=beasthost \
  -e BEASTPORT=30005 \
@@ -319,8 +304,6 @@ services:
     restart: always
     environment:
       - TZ="Australia/Perth"
-      - LAT=-33.33333
-      - LONG=111.11111
       - RECEIVER_TYPE=relay
       - BEASTHOST=beasthost
       - BEASTPORT=30005
@@ -353,8 +336,6 @@ docker run \
  --rm \
  --name piaware \
  -e TZ="Australia/Perth" \
- -e LAT=-33.33333 \
- -e LONG=111.11111 \
  -e RECEIVER_TYPE=relay \
  -e BEASTHOST=beasthost \
  -e BEASTPORT=30005
@@ -395,8 +376,6 @@ services:
     restart: always
     environment:
       - TZ="Australia/Perth"
-      - LAT=-33.33333
-      - LONG=111.11111
       - RECEIVER_TYPE=relay
       - BEASTHOST=beasthost
       - BEASTPORT=30005

--- a/rootfs/etc/cont-init.d/01-piaware
+++ b/rootfs/etc/cont-init.d/01-piaware
@@ -7,14 +7,6 @@ touch /etc/piaware.conf
 
 # Check to make sure the correct command line arguments have been set
 EXITCODE=0
-if [ -z "${LAT}" ]; then
-  echo "ERROR: LAT environment variable not set"
-  EXITCODE=1
-fi
-if [ -z "${LONG}" ]; then
-  echo "ERROR: LONG environment variable not set"
-  EXITCODE=1
-fi
 if [[ -n "${USERNAME}" ]]; then
   echo "WARNING: USERNAME environment variable is DEPRECATED and does nothing"
 fi

--- a/rootfs/etc/services.d/dump1090/run
+++ b/rootfs/etc/services.d/dump1090/run
@@ -23,8 +23,6 @@ DUMP1090_BIN="/usr/local/bin/dump1090"
 
 # Global settings
 DUMP1090_CMD=("--quiet")
-DUMP1090_CMD+=("--lat" "$LAT")
-DUMP1090_CMD+=("--lon" "$LONG")
 DUMP1090_CMD+=("--net")
 DUMP1090_CMD+=("--fix")
 DUMP1090_CMD+=("--json-location-accuracy" "2")

--- a/rootfs/etc/services.d/skyaware978/run
+++ b/rootfs/etc/services.d/skyaware978/run
@@ -25,8 +25,6 @@ set -eo pipefail
 skyaware978 \
   --connect 127.0.0.1:30978 \
   --json-dir "/run/skyaware978" \
-  --lat "$LAT" \
-  --lon "$LONG" \
   2>&1 | stdbuf -o0 sed '/^$/d' | stdbuf -o0 sed --unbuffered '/^$/d' | stdbuf -o0 awk '{print "[skyaware978] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
 
 sleep 5


### PR DESCRIPTION
Given that all of FA's official binaries and scripts do not set the LAT/LONG on the app side (they never even ask for a user's location doing this is clearly unnecessary - and for many people it seems to prevenet MLAT from working correctly.
Simply set your location on the FA website and all will be fine.