### PR TITLE
Revert "use the proper mlat client"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,8 +171,8 @@ RUN set -x && \
   popd && \
   dump1090 --version && \
   # Build & install mlat-client
-  #BRANCH_MLATCLIENT=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/mutability/mlat-client.git' | grep -v '\^' | cut -d '/' -f 3 | grep '^v.*' | tail -1) && \
-  git clone --depth 1 --branch master "https://github.com/wiedehopf/mlat-client.git" "/src/mlat-client" && \
+  BRANCH_MLATCLIENT=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' 'https://github.com/mutability/mlat-client.git' | grep -v '\^' | cut -d '/' -f 3 | grep '^v.*' | tail -1) && \
+  git clone --depth 1 --branch "$BRANCH_MLATCLIENT" "https://github.com/mutability/mlat-client.git" "/src/mlat-client" && \
   pushd /src/mlat-client && \
   BRANCH_MLATCLIENT="$(git tag --sort='-creatordate' | head -1)" && \
   echo "mlat-client ${BRANCH_MLATCLIENT}" >> /VERSIONS && \


### PR DESCRIPTION
This reverts commit e305643e670cc41da99d32a13ab49b097648e6a7. As per https://github.com/sdr-enthusiasts/docker-piaware/issues/150#issuecomment-1773993181