### PR TITLE
fixup 978 position / remove 978splitter

### DIFF
--- a/rootfs/etc/init.d/skyaware978
+++ b/rootfs/etc/init.d/skyaware978
@@ -1,0 +1,19 @@
+#!/command/with-contenv sh
+# shellcheck shell=sh
+
+# "dummy" SysV-style init script, to allow piaware to restart skyaware978.
+# piaware calls SysV init script to restart skyaware978 (package/fa_services.tcl invoke_service_action).
+# this script allows that, while still using s6-supervise.
+
+
+case "$1" in
+    restart)
+    s6-svc -r /run/service/skyaware978
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/rootfs/etc/s6-overlay/scripts/01-piaware
+++ b/rootfs/etc/s6-overlay/scripts/01-piaware
@@ -76,7 +76,7 @@ fi
 
 # If a UAT_RECEIVER_HOST is specified
 if [[ -n "$UAT_RECEIVER_HOST" ]]; then
-  piaware-config uat-receiver-type "sdr"
+  piaware-config uat-receiver-type "other"
   piaware-config uat-receiver-host "$UAT_RECEIVER_HOST"
   piaware-config uat-receiver-port "${UAT_RECEIVER_PORT:-30978}"
 

--- a/rootfs/etc/s6-overlay/scripts/978raw-splitter
+++ b/rootfs/etc/s6-overlay/scripts/978raw-splitter
@@ -4,6 +4,10 @@ set -eo pipefail
 
 source /scripts/common
 
+# DEPRECATED
+# this should no longer be needed but keep it around just in case
+stop_service
+
 # Don't continue if UAT_RECEIVER_HOST isn't set
 if [[ -z "$UAT_RECEIVER_HOST" ]]; then
     stop_service

--- a/rootfs/etc/s6-overlay/scripts/skyaware978
+++ b/rootfs/etc/s6-overlay/scripts/skyaware978
@@ -27,5 +27,5 @@ set -eo pipefail
 
 # shellcheck disable=SC2016
 exec "${s6wrap[@]}" skyaware978 \
-  --connect 127.0.0.1:30978 \
+  --connect "${UAT_RECEIVER_HOST:-127.0.0.1}:${UAT_RECEIVER_PORT:-30978}" \
   --json-dir "/run/skyaware978"


### PR DESCRIPTION
When piaware gets the location from the server, it must restart dump1090 and skyaware978 so the associated maps have their center location updated.
The container so far only allowed to restart dump1090 / dump978, add skyaware978 to init.d so it can be restarted as well.
(dump978 restart isn't needed but leaving the file in place)

The 978 splitter using socat is somewhat fragile, better to configure piaware / skyaware978 to connect to UAT_RECEIVER_HOST themselves.