### PR TITLE
fix 978 healthcheck

### DIFF
--- a/rootfs/scripts/healthcheck.sh
+++ b/rootfs/scripts/healthcheck.sh
@@ -18,7 +18,7 @@ function check_logs_for_msgs_sent_to_fa () {
     # $1 = sending process (eg: dump1090, socat, dump978-fa)
     # $2 = number of output lines to consider (every line represents 5 minutes, so 12 would be an hour)
     # ------
-    REGEX_FA_MSGS_SENT_PAST_5MIN="^\[+(?'date2'\d{4}-\d{1,2}-\d{1,2})\s+(?'time2'\d{1,2}:\d{1,2}:[\d\.]+)\]\[piaware\]\s+\d+ msgs recv'd from $1 \(\K(?'msgslast5m'\d+) in last 5m\);\s+\d+ msgs sent to FlightAware\s*$"
+    REGEX_FA_MSGS_SENT_PAST_5MIN="^\[+(?'date2'\d{4}-\d{1,2}-\d{1,2})\s+(?'time2'\d{1,2}:\d{1,2}:[\d\.]+)\]\[piaware\]\s+\d+ msgs recv'd from [^(]*$1[^(]*\(\K(?'msgslast5m'\d+) in last 5m\);\s+\d+ msgs sent to FlightAware\s*$"
     NUM_MSGS_RECEIVED=$(tail -$(($2 * 10)) /var/log/piaware/current | grep -oP "$REGEX_FA_MSGS_SENT_PAST_5MIN" | tail "-$2" | tr -s " " | cut -d " " -f 1)
     TOTAL_MSGS_RECEIVED=0
     for NUM_MSGS in $NUM_MSGS_RECEIVED; do
@@ -64,8 +64,8 @@ fi
 
 # Make sure 978MHz data is being sent to flightaware
 if [[ -n "$UAT_RECEIVER_HOST" ]]; then
-    # look for log messages from socat
-    FA_DUMP978_MSGS_SENT_PAST_HOUR=$(check_logs_for_msgs_sent_to_fa socat 24)
+    # look for log messages from UAT_RECEIVER_PORT
+    FA_DUMP978_MSGS_SENT_PAST_HOUR=$(check_logs_for_msgs_sent_to_fa $UAT_RECEIVER_PORT 24)
     if [[ "$FA_DUMP978_MSGS_SENT_PAST_HOUR" -gt 0 ]]; then
         echo "$FA_DUMP978_MSGS_SENT_PAST_HOUR dump978 messages sent in past 2 hours, OK."
     else


### PR DESCRIPTION
978 was changed to no longer use socat which broke the 978 healthcheck due to different log messages
this should fix the 978 healthcheck

fixes: https://github.com/sdr-enthusiasts/docker-piaware/issues/219